### PR TITLE
Add djikstras algorithm

### DIFF
--- a/DemonDefence/Assets/Scenes/Tactical.unity
+++ b/DemonDefence/Assets/Scenes/Tactical.unity
@@ -303,6 +303,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cab5434bc76077542bb0b4bcfbdb536b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  SelectedUnit: {fileID: 0}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -444,7 +445,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdc40596138c72043a7d5c5c743c2080, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _gridSize: 20
+  _gridSize: 50
   _tilePrefab: {fileID: 4775098393914108293, guid: 30e3c6a44828be940901d343dcb3b779, type: 3}
   _buildingTilePrefab: {fileID: 2948047609241408535, guid: 830aa47c3a5a8f04c8ce246f4b8659cf, type: 3}
   cameraObject: {fileID: 963194229}

--- a/DemonDefence/Assets/Scripts/Managers/GridManager.cs
+++ b/DemonDefence/Assets/Scripts/Managers/GridManager.cs
@@ -10,7 +10,7 @@ public class GridManager : MonoBehaviour
     /// </summary>
     /// 
 
-    
+
     [SerializeField] private int _gridSize;
     [SerializeField] private Tile _tilePrefab;
     [SerializeField] private Tile _buildingTilePrefab;
@@ -18,6 +18,12 @@ public class GridManager : MonoBehaviour
     public CameraController cameraObject;
     [SerializeField] private BuildingRegister register;
     public static GridManager Instance;
+    private Vector2[] validNeighbours = { 
+        new Vector2(0, 1), 
+        new Vector2(1, 0),
+        new Vector2(0, -1),
+        new Vector2(-1, 0)
+    };
     void Awake()
     {
         Instance = this;
@@ -70,6 +76,7 @@ public class GridManager : MonoBehaviour
                 {
                     placeTile(_tilePrefab, location);
                 }
+                
             }
         }
         cameraObject.Init(_gridSize, 10);
@@ -84,6 +91,17 @@ public class GridManager : MonoBehaviour
 
         spawnedTile.Init(vector2to3(location));
         _tiles[location] = spawnedTile;
+
+        foreach (Vector2 t in validNeighbours)
+        {
+            Vector2 neighbourLocation = location + t;
+            if (_tiles.ContainsKey(neighbourLocation))
+            {
+                _tiles[neighbourLocation].setNeighbour(spawnedTile);
+                spawnedTile.setNeighbour(_tiles[neighbourLocation]);
+                Debug.Log($"{location} is a neighbour of {neighbourLocation}");
+            }
+        }
     }
 
 
@@ -121,5 +139,18 @@ public class GridManager : MonoBehaviour
     {
         return _tiles.Where(t => t.Key.x > _gridSize / 2 && t.Value.Walkable).
             OrderBy(t => Random.value).First().Value;
+    }
+
+    public Tile getTile(Vector2 location)
+    {
+        if (_tiles.ContainsKey(location))
+        {
+            return _tiles[location];
+        }
+        else return null;
+    }
+    public int getGridSize()
+    {
+        return _gridSize;
     }
 }

--- a/DemonDefence/Assets/Scripts/Managers/GridManager.cs
+++ b/DemonDefence/Assets/Scripts/Managers/GridManager.cs
@@ -73,6 +73,7 @@ public class GridManager : MonoBehaviour
                                 placeTile(_tilePrefab, t);
                             }
                         }
+                        existingBuildings += 1;
                     }
                     else
                     {

--- a/DemonDefence/Assets/Scripts/Managers/GridManager.cs
+++ b/DemonDefence/Assets/Scripts/Managers/GridManager.cs
@@ -12,6 +12,7 @@ public class GridManager : MonoBehaviour
 
 
     [SerializeField] private int _gridSize;
+    [SerializeField] private int _maxBuildings = -1;
     [SerializeField] private Tile _tilePrefab;
     [SerializeField] private Tile _buildingTilePrefab;
     [SerializeField] private Dictionary<Vector2, Tile> _tiles;
@@ -34,15 +35,23 @@ public class GridManager : MonoBehaviour
     {
         /// Generate a grid of tile objects to the size specified in _gridSize.
         _tiles = new Dictionary<Vector2, Tile>();
+        int existingBuildings = 0;
         for (int x = 0; x < _gridSize; x++)
         {
             for (int z = 0; z < _gridSize; z++)
             {
                 Vector2 location = new Vector2(x, z);
-                if (_tiles.ContainsKey(location)){
+                if (_tiles.ContainsKey(location)) {
                     continue;
                 }
-                var placeBuilding = Random.Range(0, 5) == 3;
+                var placeBuilding = false;
+
+                if (_maxBuildings == -1 || existingBuildings < _maxBuildings)
+                {
+                    placeBuilding = Random.Range(0, 5) == 3;
+                }
+                
+
                 if (placeBuilding)
                 {
                     Building buildingToPlace = Instantiate(register.get_random_building(), 

--- a/DemonDefence/Assets/Scripts/Managers/UnitManager.cs
+++ b/DemonDefence/Assets/Scripts/Managers/UnitManager.cs
@@ -53,6 +53,11 @@ public class UnitManager : MonoBehaviour
         Debug.Log($"Select {unit}");
         if (SelectedUnit) SelectedUnit.selectionMarker.SetActive(false);
         SelectedUnit = unit;
-        if (SelectedUnit) SelectedUnit.selectionMarker.SetActive(true);
+        if (SelectedUnit)
+        {
+            unit.calculateAllTilesInRange();
+            SelectedUnit.selectionMarker.SetActive(true);
+        }
+
     }
 }

--- a/DemonDefence/Assets/Scripts/Managers/UnitManager.cs
+++ b/DemonDefence/Assets/Scripts/Managers/UnitManager.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 public class UnitManager : MonoBehaviour
 {
     public static UnitManager Instance;
+    [SerializeField] private int allies;
+    [SerializeField] private int enemies;
 
     public BasePlayerUnit SelectedUnit;
 
@@ -18,8 +20,7 @@ public class UnitManager : MonoBehaviour
 
     public void spawnPlayer()
     {
-        var playerCount = 5;
-        for (int i = 0; i < playerCount; i++)
+        for (int i = 0; i < allies; i++)
         {
             var randomPrefab = GetRandomUnit<BaseUnit>(Faction.Player);
             var spawnedUnit = Instantiate(randomPrefab);
@@ -31,8 +32,7 @@ public class UnitManager : MonoBehaviour
     }
     public void spawnEnemy()
     {
-        var enemyCount = 5;
-        for (int i = 0; i < enemyCount; i++)
+        for (int i = 0; i < enemies; i++)
         {
             var randomPrefab = GetRandomUnit<BaseUnit>(Faction.Enemy);
             var spawnedUnit = Instantiate(randomPrefab);

--- a/DemonDefence/Assets/Scripts/Pathfinding.meta
+++ b/DemonDefence/Assets/Scripts/Pathfinding.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ba53010b0b590084da4f511d1de07d29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
+++ b/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
@@ -14,7 +14,7 @@ public class NodeBase
         visited = false;
     }
     
-    public List<NodeBase> getValidTiles(int maxDistance, int currentDistance = 0)
+    public List<NodeBase> getValidTiles(int maxDistance, Faction faction, int currentDistance = 0)
     {
         List<NodeBase> tiles = new List<NodeBase>();
         visited = true;
@@ -24,7 +24,9 @@ public class NodeBase
 
         foreach (Tile t in referenceTile.getNeighbours())
         {
-            if(!(t.Walkable))
+            bool tileHasEnemy = t.occupiedUnit && t.occupiedUnit.faction != faction;
+
+            if(!(t.Walkable) && !tileHasEnemy)
                 continue;
             if (!tiles.Exists(n => n.referenceTile == t)) {
                 NodeBase newNode = new NodeBase(t);
@@ -39,9 +41,9 @@ public class NodeBase
                 tiles[index].visited = false;
             };
 
-            if (tiles[index].visited) continue;
+            if (tiles[index].visited || tileHasEnemy) continue;
 
-            tiles.AddRange(tiles[index].getValidTiles(maxDistance, nextDistance));
+            tiles.AddRange(tiles[index].getValidTiles(maxDistance, faction, nextDistance));
         }
 
         return tiles;

--- a/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
+++ b/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
@@ -33,9 +33,13 @@ public class NodeBase
 
             int index = tiles.FindIndex(n => n.referenceTile == t);
 
-            if (tiles[index].visited) continue;
+            if (tiles[index].distance > nextDistance)
+            {
+                tiles[index].distance = nextDistance;
+                tiles[index].visited = false;
+            };
 
-            if (tiles[index].distance > nextDistance) tiles[index].distance = nextDistance;
+            if (tiles[index].visited) continue;
 
             tiles.AddRange(tiles[index].getValidTiles(maxDistance, nextDistance));
         }

--- a/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
+++ b/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
@@ -14,8 +14,9 @@ public class NodeBase
         visited = false;
     }
     
-    public List<NodeBase> getValidTiles(int maxDistance, List<NodeBase> tiles, int currentDistance = 0)
+    public List<NodeBase> getValidTiles(int maxDistance, int currentDistance = 0)
     {
+        List<NodeBase> tiles = new List<NodeBase>();
         visited = true;
         if (currentDistance == maxDistance) return tiles;
 
@@ -23,7 +24,7 @@ public class NodeBase
 
         foreach (Tile t in referenceTile.getNeighbours())
         {
-            if (!(t.Walkable))
+            if(!(t.Walkable))
                 continue;
             if (!tiles.Exists(n => n.referenceTile == t)) {
                 NodeBase newNode = new NodeBase(t);
@@ -36,7 +37,7 @@ public class NodeBase
 
             if (tiles[index].distance > nextDistance) tiles[index].distance = nextDistance;
 
-            tiles = tiles[index].getValidTiles(maxDistance, tiles, nextDistance);
+            tiles.AddRange(tiles[index].getValidTiles(maxDistance, nextDistance));
         }
 
         return tiles;

--- a/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
+++ b/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class NodeBase
+{
+    public Tile referenceTile;
+    public bool visited;
+    public int distance;
+    public NodeBase(Tile input, int defsaultDistance = 1000)
+    {
+        referenceTile = input;
+        distance = defsaultDistance;
+        visited = false;
+    }
+    
+    public List<NodeBase> getValidTiles(int maxDistance, List<NodeBase> tiles, int currentDistance = 0)
+    {
+        visited = true;
+        if (currentDistance == maxDistance) return tiles;
+
+        int nextDistance = currentDistance + 1;
+
+        foreach (Tile t in referenceTile.getNeighbours())
+        {
+            if (!(t.Walkable))
+                continue;
+            if (!tiles.Exists(n => n.referenceTile == t)) {
+                NodeBase newNode = new NodeBase(t);
+                tiles.Add(newNode);
+            }
+
+            int index = tiles.FindIndex(n => n.referenceTile == t);
+
+            if (tiles[index].visited) continue;
+
+            if (tiles[index].distance > nextDistance) tiles[index].distance = nextDistance;
+
+            tiles = tiles[index].getValidTiles(maxDistance, tiles, nextDistance);
+        }
+
+        return tiles;
+    }
+
+}

--- a/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs.meta
+++ b/DemonDefence/Assets/Scripts/Pathfinding/NodeBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65f31a87660fdf14297651a918ef6cfa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DemonDefence/Assets/Scripts/Tiles/GroundTile.cs
+++ b/DemonDefence/Assets/Scripts/Tiles/GroundTile.cs
@@ -28,7 +28,7 @@ public class Ground : Tile
 
     private void Update()
     {
-        if(UnitManager.Instance.SelectedUnit && UnitManager.Instance.SelectedUnit.isInRange(transform.position))
+        if(UnitManager.Instance.SelectedUnit && UnitManager.Instance.SelectedUnit.isInRangeTile(this))
             _validHighlight.SetActive(true);
         else
             _validHighlight.SetActive(false);

--- a/DemonDefence/Assets/Scripts/Tiles/Tile.cs
+++ b/DemonDefence/Assets/Scripts/Tiles/Tile.cs
@@ -82,7 +82,7 @@ public abstract class Tile : MonoBehaviour
             }
             else
             {
-                if (UnitManager.Instance.SelectedUnit.isInRange(transform.position) 
+                if (UnitManager.Instance.SelectedUnit.isInRangeTile(this)
                     && UnitManager.Instance.SelectedUnit != null)
                 {
                     var enemy = (BaseEnemy)occupiedUnit;
@@ -94,7 +94,7 @@ public abstract class Tile : MonoBehaviour
         }
         else if (UnitManager.Instance.SelectedUnit != null)
         {
-            if (UnitManager.Instance.SelectedUnit.isInRange(transform.position))
+            if (UnitManager.Instance.SelectedUnit.isInRangeTile(this))
             {
                 SetUnit(UnitManager.Instance.SelectedUnit);
                 UnitManager.Instance.SetSelectedHero(null);

--- a/DemonDefence/Assets/Scripts/Tiles/Tile.cs
+++ b/DemonDefence/Assets/Scripts/Tiles/Tile.cs
@@ -13,6 +13,7 @@ public abstract class Tile : MonoBehaviour
     [SerializeField] protected List<Material> materials = new List<Material>();
     [SerializeField] private bool _isWalkable;
     public BaseUnit occupiedUnit;
+    private List<Tile> neighbours = new List<Tile>();
 
     public bool Walkable => _isWalkable && occupiedUnit == null;
 
@@ -28,6 +29,27 @@ public abstract class Tile : MonoBehaviour
         unit.OccupiedTile = this;
     }
 
+    public void setNeighbour(Tile neighbour)
+    {
+        neighbours.Add(neighbour);
+    }
+
+    public List<Tile> getNeighbours()
+    {
+        return neighbours;
+    }
+
+    public string getNeighbourList()
+    {
+        string neighbourList = $"Neighbours of {get2dLocation()}:";
+        foreach (Tile t in neighbours)
+        {
+            neighbourList = neighbourList + $"{t.get2dLocation()} ";
+        }
+
+        return neighbourList;
+    }
+
     private void OnMouseEnter()
     {
         /// Activates when the mouse is over a tile
@@ -39,8 +61,14 @@ public abstract class Tile : MonoBehaviour
         _highlight.SetActive(false);
     }
 
+    public Vector2 get2dLocation()
+    {
+        return new Vector2(transform.position.x, transform.position.z);
+    }
     private void OnMouseDown()
     {
+        Debug.Log(getNeighbourList());
+
         if (GameManager.Instance.State != GameState.PlayerTurn) return;
 
         if (!_isWalkable) return;

--- a/DemonDefence/Assets/Scripts/Units/BaseUnit.cs
+++ b/DemonDefence/Assets/Scripts/Units/BaseUnit.cs
@@ -7,9 +7,33 @@ public class BaseUnit : MonoBehaviour
     public Tile OccupiedTile;
     public Faction faction;
     public int maxMovement;
+    public List<Tile> inRangeTiles;
+
+    public bool isInRangeTile(Tile destination)
+    {
+        if (inRangeTiles.Count >= 0) return inRangeTiles.Contains(destination);
+        else return false;
+    }
     public bool isInRange(Vector3 location)
     {
         return (location - transform.position).magnitude <= maxMovement * 10;
 
     }
+
+    public void calculateAllTilesInRange()
+    {
+        List<NodeBase> nodes = new List<NodeBase>();
+        NodeBase originNode = new NodeBase(OccupiedTile, 0);
+        nodes.Add(originNode);
+        nodes = nodes[0].getValidTiles(maxMovement, nodes);
+
+        inRangeTiles = new List<Tile>();
+
+        foreach (NodeBase n in nodes){
+            inRangeTiles.Add(n.referenceTile);
+        }
+
+    }
+
+    
 }

--- a/DemonDefence/Assets/Scripts/Units/BaseUnit.cs
+++ b/DemonDefence/Assets/Scripts/Units/BaseUnit.cs
@@ -25,7 +25,7 @@ public class BaseUnit : MonoBehaviour
         List<NodeBase> nodes = new List<NodeBase>();
         NodeBase originNode = new NodeBase(OccupiedTile, 0);
         nodes.Add(originNode);
-        nodes = nodes[0].getValidTiles(maxMovement);
+        nodes = nodes[0].getValidTiles(maxMovement, faction);
 
         inRangeTiles = new List<Tile>();
 

--- a/DemonDefence/Assets/Scripts/Units/BaseUnit.cs
+++ b/DemonDefence/Assets/Scripts/Units/BaseUnit.cs
@@ -25,7 +25,7 @@ public class BaseUnit : MonoBehaviour
         List<NodeBase> nodes = new List<NodeBase>();
         NodeBase originNode = new NodeBase(OccupiedTile, 0);
         nodes.Add(originNode);
-        nodes = nodes[0].getValidTiles(maxMovement, nodes);
+        nodes = nodes[0].getValidTiles(maxMovement);
 
         inRangeTiles = new List<Tile>();
 


### PR DESCRIPTION
Implements Djikstra's algorithm to allow for player unit pathfinding. This makes use of a new BaseNode class, containing a Tile reference, a Distance, and a Visited toggle. As the player unit needs to determine all viable paths, 'Visited' will be toggled on when the algorithm runs on the tile, and 'off' if a shorter path is found (allowing the tile to be rescanned). This can be revisited in future to try and streamline the process.

Enemy units will use a form of A* pathfinding which can be built on top of the existing framework, though will need its own functions to achieve. This will be implemented in a future pull request.